### PR TITLE
The std out logger needs to be installed directly from github...

### DIFF
--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -29,11 +29,11 @@ password = dummy
 ; interpreted as relative to this file.  Included files *cannot*
 ; include files themselves.
 
-; [eventlistener:stdout]
-; command = supervisor_stdout
-; buffer_size = 4096
-; events = PROCESS_LOG
-; result_handler = supervisor_stdout:event_handler
+[eventlistener:stdout]
+command = supervisor_stdout
+buffer_size = 4096
+events = PROCESS_LOG
+result_handler = supervisor_stdout:event_handler
 
 [program:uwsgi]
 command = /usr/bin/uwsgi --ini /etc/uwsgi/apps-enabled/weblate.ini

--- a/mscli-Dockerfile
+++ b/mscli-Dockerfile
@@ -94,6 +94,7 @@ RUN set -x \
   && python3 -m pip install --upgrade pip \
   && pip3 install --force-reinstall --no-binary :all: cffi \
   && pip3 install /usr/src \
+  && pip3 install git+https://github.com/coderanger/supervisor-stdout.git \
   && python3 -c 'from phply.phpparse import make_parser; make_parser()' \
   && ln -s /usr/local/share/weblate/examples/ /app/ \
   && apt-get -y purge \


### PR DESCRIPTION
no pypi package for python 3 was ever released


