### PR TITLE
fix: postgres ssl (copy from previous) start file

### DIFF
--- a/start
+++ b/start
@@ -84,12 +84,34 @@ export WEBLATE_PY_PATH="/app/data/python/customize"
 
 # Provide sane default value
 if [ -z "$POSTGRES_SSL_MODE" ] ; then
+    # not running ssl
+    export POSTGRES_SSL_MODE="allow"
+else
     export POSTGRES_SSL_MODE="prefer"
-fi
 
-# Export variables for psql use
-export PGPASSWORD="$POSTGRES_PASSWORD"
-export PGSSLMODE="$POSTGRES_SSL_MODE"
+    # Export variables for psql use
+    export PGPASSWORD="$POSTGRES_PASSWORD"
+    export PGSSLMODE="$POSTGRES_SSL_MODE"
+
+    # PSQL expects the secrets to only have user permissions, and not group/world permissions.
+    # For some reason, mounting the secrets with the permission mode doesn't change them.
+    # Manually copy them and change the permissions.
+    cp $POSTGRES_CLI_SSL_CA $HOME
+    cp $POSTGRES_CLI_SSL_CRT $HOME
+    cp $POSTGRES_CLI_SSL_KEY $HOME
+
+    export POSTGRES_CLI_SSL_CA="$HOME/$(basename $POSTGRES_CLI_SSL_CA)"
+    export POSTGRES_CLI_SSL_CRT="$HOME/$(basename $POSTGRES_CLI_SSL_CRT)"
+    export POSTGRES_CLI_SSL_KEY="$HOME/$(basename $POSTGRES_CLI_SSL_KEY)"
+
+    export PGSSLROOTCERT="$POSTGRES_CLI_SSL_CA"
+    export PGSSLCERT="$POSTGRES_CLI_SSL_CRT"
+    export PGSSLKEY="$POSTGRES_CLI_SSL_KEY"
+
+    chmod 0600 $POSTGRES_CLI_SSL_CA
+    chmod 0600 $POSTGRES_CLI_SSL_CRT
+    chmod 0600 $POSTGRES_CLI_SSL_KEY
+fi
 
 # Update the time zone
 zonefile="/usr/share/zoneinfo/$WEBLATE_TIME_ZONE"


### PR DESCRIPTION
Fix: postgres is failing to start because of cert errors. Recover the previous work arounds that existed. 

Configuration of ssl can be found here: https://www.postgresql.org/docs/current/libpq-ssl.html