### PR TITLE
fix: bug in translations query

### DIFF
--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -177,7 +177,7 @@ def show_project(request, project):
             .order()
         )
         for language in obj_languages:
-            result.append(obj.stats.get_single_language_stats(language, prefetch=True))
+            result.append(obj.stats.get_single_language_stats(language))
         language_stats = prefetch_stats(result)
 
     # Show ghost translations for user languages
@@ -283,7 +283,7 @@ def show_component(request, project, component):
                 | Q(language_code__contains=NAMESPACE_SEPARATOR + namespace)
             )
 
-    translations = prefetch_stats(list(obj.translations_query.prefetch()))
+    translations = prefetch_stats(list(translations_query.prefetch()))
 
     # Show ghost translations for user languages
     add_ghost_translations(obj, user, translations, GhostTranslation)


### PR DESCRIPTION
Translations queries are not correct. 

One error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/decorators/cache.py", line 62, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/weblate/trans/views/basic.py", line 180, in show_project
    result.append(obj.stats.get_single_language_stats(language, prefetch=True))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

One bad merge conflict. 