### PR TITLE
fix: auto translations are not working

### DIFF
--- a/weblate/addons/autotranslate.py
+++ b/weblate/addons/autotranslate.py
@@ -12,7 +12,6 @@ from weblate.addons.base import BaseAddon
 from weblate.addons.events import EVENT_COMPONENT_UPDATE, EVENT_DAILY
 from weblate.addons.forms import AutoAddonForm
 from weblate.trans.tasks import auto_translate_component
-from weblate.vendasta.constants import NAMESPACE_SEPARATOR
 
 
 class AutoTranslateAddon(BaseAddon):
@@ -28,16 +27,11 @@ class AutoTranslateAddon(BaseAddon):
     icon = "language.svg"
 
     def component_update(self, component):
-        for translation in component.translation_set.iterator():
-            if translation.is_source:
-                continue
-            if NAMESPACE_SEPARATOR in translation.language_code:
-                continue
-            transaction.on_commit(
-                lambda: auto_translate_component.delay(
-                    None, translation.pk, **self.instance.configuration
-                )
+        transaction.on_commit(
+            lambda: auto_translate_component.delay(
+                component.pk, **self.instance.configuration
             )
+        )
 
     def daily(self, component):
         # Translate every component less frequenctly to reduce load.

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -38,6 +38,7 @@ from weblate.utils.files import remove_tree
 from weblate.utils.lock import WeblateLockTimeout
 from weblate.utils.stats import prefetch_stats
 from weblate.vcs.base import RepositoryException
+from weblate.vendasta.constants import NAMESPACE_SEPARATOR
 
 
 @app.task(
@@ -442,6 +443,8 @@ def auto_translate_component(
 
     for translation in component_obj.translation_set.iterator():
         if translation.is_source:
+            continue
+        if NAMESPACE_SEPARATOR in translation.language_code:
             continue
 
         auto_translate(


### PR DESCRIPTION
Auto translate has been broken since we modified this code. The component id is required for this code to actually work. Push component updates further down into the code that actually can bail out for namespaced translations

<img width="1646" alt="image" src="https://github.com/vendasta/weblate/assets/2300103/c4098948-5bce-485e-8010-d5b03c402872">
