### PR TITLE
fix import error caused by redis.connection module HiredisParser

### DIFF
--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1166,7 +1166,6 @@ CACHES = {
         # "LOCATION": "unix:///var/run/redis/redis.sock?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "PARSER_CLASS": "redis.connection.HiredisParser",
             # If you set password here, adjust CELERY_BROKER_URL as well
             "PASSWORD": REDIS_PASSWORD if REDIS_PASSWORD else None,
             "CONNECTION_POOL_KWARGS": {},

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -808,7 +808,6 @@ CACHES = {
         # "LOCATION": "unix:///var/run/redis/redis.sock?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "PARSER_CLASS": "redis.connection.HiredisParser",
             # If you set password here, adjust CELERY_BROKER_URL as well
             "PASSWORD": None,
             "CONNECTION_POOL_KWARGS": {},


### PR DESCRIPTION
## Proposed changes

Remove explicit PARSER_CLASS from redis configuration. This was causing a runtime error preventing weblate containers from starting up. See attached error in the image below. This change was made in the main weblate repository earlier this year ([commit](https://github.com/WeblateOrg/weblate/commit/f990e0a5e0087b905b4d96e6bd926cff2a3c8de8)).

I resolved this error in a local weblate build on my machine.

<img width="648" alt="Screenshot 2023-12-12 at 1 33 46 PM" src="https://github.com/vendasta/weblate/assets/83599192/fc54fa66-7cae-45bb-8daf-97bbac685839">

@jredl-va
@brentyates 
@vendasta/sre 