### PR TITLE
remove google api from translation services on demo

### DIFF
--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -822,11 +822,17 @@ if not HAVE_SYSLOG:
     del LOGGING["handlers"]["syslog"]
 
 # List of machine translations
-MT_SERVICES = (
-    "weblate.machinery.weblatetm.WeblateTranslation",
-    "weblate.memory.machine.WeblateMemory",
-    "weblate.machinery.googlev3.GoogleV3Translation",
-)
+if os.environ.get("ENVIRONMENT") == "prod":
+    MT_SERVICES = (
+        "weblate.machinery.weblatetm.WeblateTranslation",
+        "weblate.memory.machine.WeblateMemory",
+        "weblate.machinery.googlev3.GoogleV3Translation",
+    )
+else:
+    MT_SERVICES = (
+        "weblate.machinery.weblatetm.WeblateTranslation",
+        "weblate.memory.machine.WeblateMemory",
+    )
 
 # Machine translation API keys
 


### PR DESCRIPTION
## Proposed changes

Use Google's translation API only on prod.

The weblate container is running into the error below on pod startup in the demo namespace. The prod environment does not set `MT_GOOGLE_CREDENTIALS` either, so my belief is that prod is able to use the Google API thanks to the [credentials set in Weblate's UI](https://weblate.apigateway.co/manage/machinery/google-translate-api-v3/), which are likely residing on prod's persistent volume which is not shared with demo.

Gitops PR that adds the `ENVIRONMENT` environment variable to weblate deployments: 
https://github.com/vendasta/gitops/pull/825

An alternative solution is to clone the prod persistent volume and mount the clone to the weblate-demo pod. The solution in this PR is simpler however, as it removes the use of Google's API on demo entirely.

![Screenshot 2023-12-14 at 5 27 09 PM](https://github.com/vendasta/weblate/assets/83599192/f26f52a1-9770-49b3-95b3-5d0e59514d89)

@jredl-va 
@brentyates 
@venadsta/sre

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
