### PR TITLE
VSRE-1450: Update service to use new Redis prod IP

### DIFF
--- a/microservice.yaml
+++ b/microservice.yaml
@@ -67,7 +67,7 @@ microservice:
       - key: POSTGRES_DATABASE
         value: "weblate"
       - key: REDIS_HOST
-        value: "10.44.36.108"
+        value: "10.180.144.67"
       - key: REDIS_PORT
         value: "6379"
       - key: WEBLATE_ADMIN_NAME


### PR DESCRIPTION
## Problem
As part of our Redis migration, we would like to start cutting over production microservices to use their new prod redis instance.

**RFC**: https://vendasta.jira.com/wiki/spaces/RD/pages/2631467009/Redis+Migration+Transition+to+7.x+and+Optimize+Resources#Test-Plan
**Story**: https://vendasta.jira.com/browse/VSRE-1450
**Old Instance**: https://console.cloud.google.com/memorystore/redis/locations/us-central1/instances/weblate-prod/details/overview?project=repcore-prod
**New Instance**: https://console.cloud.google.com/memorystore/redis/locations/us-central1/instances/weblate-v2-prod/details/overview?project=repcore-prod

@vendasta/sre